### PR TITLE
Task 3: Undo add and remove from reading list

### DIFF
--- a/apps/okreads-e2e/src/integration/reading-list.spec.ts
+++ b/apps/okreads-e2e/src/integration/reading-list.spec.ts
@@ -11,4 +11,45 @@ describe('When: I use the reading list feature', () => {
       'My Reading List'
     );
   });
+
+  it('Then: I should be able to add an item to the list and then undo', () => {
+    cy.searchBooks('javascript');
+
+    // required to cover the edge case scenario when reading list is empty
+    cy.addToReadingList();
+    // initial count of reading list item
+    cy.readingListItem().then(initialItemCount => {
+      cy.addToReadingList();
+
+      cy.undoAction();
+
+      // final count of reading list
+      cy.readingListItem().then(finalItemCount => {
+        expect(initialItemCount).to.equal(finalItemCount);
+      });
+    });
+  });
+
+
+  it('Then:  I should be able to remove an item from the list and then undo', () => {
+    cy.searchBooks('javascript');
+
+    cy.addToReadingList();
+
+    // open reading list
+    cy.get('[data-testing="toggle-reading-list"]').click();
+
+    // initial count of reading list item
+    cy.readingListItem().then(initialItemCount => {
+
+      cy.removeFromReadingList();
+
+      cy.undoAction();
+
+      // final count of reading list item
+      cy.readingListItem().then(finalItemCount => {
+        expect(initialItemCount).to.equal(finalItemCount);
+      });
+    });
+  });
 });

--- a/apps/okreads-e2e/src/support/commands.ts
+++ b/apps/okreads-e2e/src/support/commands.ts
@@ -8,6 +8,11 @@ declare global {
   namespace Cypress {
     interface Chainable {
       startAt: typeof startAt;
+      searchBooks: typeof searchBooks;
+      addToReadingList: typeof addToReadingList;
+      removeFromReadingList: typeof removeFromReadingList;
+      readingListItem: typeof readingListItem;
+      undoAction: typeof undoAction;
     }
   }
 }
@@ -17,4 +22,30 @@ export function startAt(url) {
   cy.get('tmo-root').should('contain.text', 'okreads');
 }
 
+export function searchBooks(book: string) {
+  cy.get('input[type="search"]').type('javascript');
+  cy.get('form').submit();
+}
+
+export function addToReadingList() {
+  cy.get('[data-testing="add-book-button"]:enabled').first().should('exist').click();
+}
+
+export function removeFromReadingList() {
+  cy.get('[data-testing="remove-book-button"]:enabled').last().should('exist').click();
+}
+
+export function readingListItem() {
+  return cy.get('tmo-total-count [ng-reflect-content]').invoke('attr', 'ng-reflect-content');
+}
+
+export function undoAction() {
+  cy.get('.mat-simple-snackbar-action').last().should('exist').click();
+}
+
 Cypress.Commands.add('startAt', startAt);
+Cypress.Commands.add('searchBooks', searchBooks);
+Cypress.Commands.add('addToReadingList', addToReadingList);
+Cypress.Commands.add('removeFromReadingList', removeFromReadingList);
+Cypress.Commands.add('readingListItem', readingListItem);
+Cypress.Commands.add('undoAction', undoAction);

--- a/libs/books/data-access/src/lib/+state/reading-list.actions.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.actions.ts
@@ -14,7 +14,7 @@ export const loadReadingListError = createAction(
 
 export const addToReadingList = createAction(
   '[Books Search Results] Add to list',
-  props<{ book: Book }>()
+  props<{ book: Book, add: boolean }>()
 );
 
 export const failedAddToReadingList = createAction(
@@ -24,12 +24,12 @@ export const failedAddToReadingList = createAction(
 
 export const confirmedAddToReadingList = createAction(
   '[Reading List API] Confirmed add to list',
-  props<{ book: Book }>()
+  props<{ book: Book,  add: boolean }>()
 );
 
 export const removeFromReadingList = createAction(
   '[Books Search Results] Remove from list',
-  props<{ item: ReadingListItem }>()
+  props<{ item: ReadingListItem,  remove:boolean  }>()
 );
 
 export const failedRemoveFromReadingList = createAction(
@@ -39,5 +39,5 @@ export const failedRemoveFromReadingList = createAction(
 
 export const confirmedRemoveFromReadingList = createAction(
   '[Reading List API] Confirmed remove from list',
-  props<{ item: ReadingListItem }>()
+  props<{ item: ReadingListItem, remove:boolean  }>()
 );

--- a/libs/books/data-access/src/lib/+state/reading-list.effects.spec.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.effects.spec.ts
@@ -1,5 +1,5 @@
 import { fakeAsync, TestBed } from '@angular/core/testing';
-import { ReplaySubject } from 'rxjs';
+import { ReplaySubject, Subject  } from 'rxjs';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { HttpTestingController } from '@angular/common/http/testing';
@@ -9,6 +9,7 @@ import { ReadingListEffects } from './reading-list.effects';
 import * as ReadingListActions from './reading-list.actions';
 import { MatSnackBar, MatSnackBarModule, MatSnackBarRef } from '@angular/material/snack-bar';
 import { Book, ReadingListItem } from '@tmo/shared/models';
+import { takeUntil } from 'rxjs/operators';
 
 
 describe('ToReadEffects', () => {
@@ -19,6 +20,7 @@ describe('ToReadEffects', () => {
   let book: Book;
   let snackbar: MatSnackBar;
   let store : MockStore;
+  let unsubscribe$: Subject<void>;
 
   const bookItem = createReadingListItem('A');
   const itemBook = createBook('B');
@@ -44,13 +46,20 @@ describe('ToReadEffects', () => {
     actions = new ReplaySubject();
     store = TestBed.inject(MockStore);
     snackbar = TestBed.inject(MatSnackBar);
+    unsubscribe$ = new Subject<void>();
   });
+
+  afterEach (()=>{
+    unsubscribe$.next();
+    unsubscribe$.complete();
+  })
 
   describe('loadReadingList$', () => {
     it('should fetch reading list successfully', done => {
       actions.next(ReadingListActions.init());
 
-      effects.loadReadingList$.subscribe(action => {
+      effects.loadReadingList$.pipe(takeUntil(unsubscribe$))
+        .subscribe((action) => {
         expect(action).toEqual(
           ReadingListActions.loadReadingListSuccess({ list: [] })
         );
@@ -65,7 +74,8 @@ describe('ToReadEffects', () => {
     it('should add a book to the reading list successfully', fakeAsync(() => {
       actions.next(ReadingListActions.addToReadingList({ book, add: false  }));
 
-      effects.addBook$.subscribe(action => {
+      effects.addBook$.pipe(takeUntil(unsubscribe$))
+      .subscribe((action) => {
         expect(action).toEqual(
           ReadingListActions.confirmedAddToReadingList({ book, add: false })
         );
@@ -78,7 +88,8 @@ describe('ToReadEffects', () => {
     it('should undo the added book when API returns error', fakeAsync(() => {
       actions.next(ReadingListActions.addToReadingList({ book, add: false}));
 
-      effects.addBook$.subscribe(action => {
+      effects.addBook$.pipe(takeUntil(unsubscribe$))
+      .subscribe((action) => {
         expect(action).toEqual(
           ReadingListActions.failedAddToReadingList({ book })
         );
@@ -92,7 +103,8 @@ describe('ToReadEffects', () => {
       actions = new ReplaySubject();
       actions.next(ReadingListActions.confirmedAddToReadingList({ book, add:false }));
 
-      effects.showSnackBarOnAdd$.subscribe(() => {
+      effects.addBook$.pipe(takeUntil(unsubscribe$))
+        .subscribe(() => {
         snackbar.open(`Added ${book.title} to reading list`,'Undo', { duration: 2000}).onAction().subscribe((action)=>{
           expect(action).toEqual(
             ReadingListActions.removeFromReadingList({ item:bookItem, remove:true })
@@ -107,7 +119,8 @@ describe('ToReadEffects', () => {
     it('should remove book successfully from reading list', done => {
       actions.next(ReadingListActions.removeFromReadingList({ item, remove: false }));
 
-      effects.removeBook$.subscribe(action => {
+      effects.removeBook$.pipe(takeUntil(unsubscribe$))
+      .subscribe((action) => {
         expect(action).toEqual(
           ReadingListActions.confirmedRemoveFromReadingList({ item, remove: false  })
         );
@@ -122,7 +135,8 @@ describe('ToReadEffects', () => {
     it('should undo removed book when API returns error', fakeAsync(() => {
       actions.next(ReadingListActions.removeFromReadingList({ item, remove: false  }));
 
-      effects.removeBook$.subscribe(action => {
+      effects.removeBook$.pipe(takeUntil(unsubscribe$))
+      .subscribe((action) => {
         expect(action).toEqual(
           ReadingListActions.failedRemoveFromReadingList({ item })
         );
@@ -135,7 +149,8 @@ describe('ToReadEffects', () => {
       actions = new ReplaySubject();
       actions.next(ReadingListActions.confirmedRemoveFromReadingList({ item, remove:false }));
 
-      effects.showSnackBarOnRemove$.subscribe(() => {
+      effects.removeBook$.pipe(takeUntil(unsubscribe$))
+        .subscribe(() => {
         snackbar.open(`Removed ${item.title} to reading list`,'Undo', { duration: 2000}).onAction().subscribe((action)=>{
           expect(action).toEqual(
             ReadingListActions.addToReadingList({ book:itemBook, add:true })

--- a/libs/books/data-access/src/lib/+state/reading-list.effects.spec.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.effects.spec.ts
@@ -1,23 +1,39 @@
-import { TestBed } from '@angular/core/testing';
+import { fakeAsync, TestBed } from '@angular/core/testing';
 import { ReplaySubject } from 'rxjs';
 import { provideMockActions } from '@ngrx/effects/testing';
-import { provideMockStore } from '@ngrx/store/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { HttpTestingController } from '@angular/common/http/testing';
 
-import { SharedTestingModule } from '@tmo/shared/testing';
+import { createBook, createReadingListItem, SharedTestingModule } from '@tmo/shared/testing';
 import { ReadingListEffects } from './reading-list.effects';
 import * as ReadingListActions from './reading-list.actions';
+import { MatSnackBar, MatSnackBarModule, MatSnackBarRef } from '@angular/material/snack-bar';
+import { Book, ReadingListItem } from '@tmo/shared/models';
+
 
 describe('ToReadEffects', () => {
   let actions: ReplaySubject<any>;
   let effects: ReadingListEffects;
   let httpMock: HttpTestingController;
+  let item: ReadingListItem;
+  let book: Book;
+  let snackbar: MatSnackBar;
+  let store : MockStore;
+
+  const bookItem = createReadingListItem('A');
+  const itemBook = createBook('B');
+
+  beforeAll(() => {
+    item = createReadingListItem('A');      
+    book = createBook('A');
+  })
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [SharedTestingModule],
+      imports: [SharedTestingModule, MatSnackBarModule],
       providers: [
         ReadingListEffects,
+        { provide: MatSnackBar, useVale: {open: (param1, param2) => { return; }}},
         provideMockActions(() => actions),
         provideMockStore()
       ]
@@ -25,11 +41,13 @@ describe('ToReadEffects', () => {
 
     effects = TestBed.inject(ReadingListEffects);
     httpMock = TestBed.inject(HttpTestingController);
+    actions = new ReplaySubject();
+    store = TestBed.inject(MockStore);
+    snackbar = TestBed.inject(MatSnackBar);
   });
 
   describe('loadReadingList$', () => {
-    it('should work', done => {
-      actions = new ReplaySubject();
+    it('should fetch reading list successfully', done => {
       actions.next(ReadingListActions.init());
 
       effects.loadReadingList$.subscribe(action => {
@@ -42,4 +60,92 @@ describe('ToReadEffects', () => {
       httpMock.expectOne('/api/reading-list').flush([]);
     });
   });
+  
+  describe('addBook$', () => {
+    it('should add a book to the reading list successfully', fakeAsync(() => {
+      actions.next(ReadingListActions.addToReadingList({ book, add: false  }));
+
+      effects.addBook$.subscribe(action => {
+        expect(action).toEqual(
+          ReadingListActions.confirmedAddToReadingList({ book, add: false })
+        );
+      })
+
+      httpMock.expectOne('/api/reading-list').flush({});
+    }));
+
+
+    it('should undo the added book when API returns error', fakeAsync(() => {
+      actions.next(ReadingListActions.addToReadingList({ book, add: false}));
+
+      effects.addBook$.subscribe(action => {
+        expect(action).toEqual(
+          ReadingListActions.failedAddToReadingList({ book })
+        );
+      });
+
+      httpMock.expectOne('/api/reading-list').flush({}, { status: 500, statusText: 'server error' });
+
+    }));
+
+    it('show snackbar on add book', async() => {
+      actions = new ReplaySubject();
+      actions.next(ReadingListActions.confirmedAddToReadingList({ book, add:false }));
+
+      effects.showSnackBarOnAdd$.subscribe(() => {
+        snackbar.open(`Added ${book.title} to reading list`,'Undo', { duration: 2000}).onAction().subscribe((action)=>{
+          expect(action).toEqual(
+            ReadingListActions.removeFromReadingList({ item:bookItem, remove:true })
+        )
+        })
+      });
+    });
+
+  });  
+
+  describe('removeBook$', () => {
+    it('should remove book successfully from reading list', done => {
+      actions.next(ReadingListActions.removeFromReadingList({ item, remove: false }));
+
+      effects.removeBook$.subscribe(action => {
+        expect(action).toEqual(
+          ReadingListActions.confirmedRemoveFromReadingList({ item, remove: false  })
+        );
+
+        done();
+      });
+
+      httpMock.expectOne(`/api/reading-list/${item.bookId}`).flush({});
+    });
+
+
+    it('should undo removed book when API returns error', fakeAsync(() => {
+      actions.next(ReadingListActions.removeFromReadingList({ item, remove: false  }));
+
+      effects.removeBook$.subscribe(action => {
+        expect(action).toEqual(
+          ReadingListActions.failedRemoveFromReadingList({ item })
+        );
+      });
+
+      httpMock.expectOne(`/api/reading-list/${item.bookId}`).flush({}, { status: 500, statusText: 'server error' });
+    }));
+
+    it('show snackbar on remove book', async() => {
+      actions = new ReplaySubject();
+      actions.next(ReadingListActions.confirmedRemoveFromReadingList({ item, remove:false }));
+
+      effects.showSnackBarOnRemove$.subscribe(() => {
+        snackbar.open(`Removed ${item.title} to reading list`,'Undo', { duration: 2000}).onAction().subscribe((action)=>{
+          expect(action).toEqual(
+            ReadingListActions.addToReadingList({ book:itemBook, add:true })
+          );
+        })
+      });
+    });
+
+  });
+
 });
+
+

--- a/libs/books/data-access/src/lib/+state/reading-list.effects.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.effects.ts
@@ -2,12 +2,17 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Actions, createEffect, ofType, OnInitEffects } from '@ngrx/effects';
 import { of } from 'rxjs';
-import { catchError, concatMap, exhaustMap, map } from 'rxjs/operators';
-import { ReadingListItem } from '@tmo/shared/models';
+import { catchError, concatMap, exhaustMap, map, tap, switchMap  } from 'rxjs/operators';
+import { ReadingListItem, Book } from '@tmo/shared/models';
 import * as ReadingListActions from './reading-list.actions';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Store } from '@ngrx/store';
+import { TypedAction } from '@ngrx/store/src/models';
 
 @Injectable()
 export class ReadingListEffects implements OnInitEffects {
+ 
+
   loadReadingList$ = createEffect(() =>
     this.actions$.pipe(
       ofType(ReadingListActions.init),
@@ -27,9 +32,9 @@ export class ReadingListEffects implements OnInitEffects {
   addBook$ = createEffect(() =>
     this.actions$.pipe(
       ofType(ReadingListActions.addToReadingList),
-      concatMap(({ book }) =>
+      concatMap(({ book, add }) =>
         this.http.post('/api/reading-list', book).pipe(
-          map(() => ReadingListActions.confirmedAddToReadingList({ book })),
+          map(() => ReadingListActions.confirmedAddToReadingList({ book,add  })),
           catchError(() =>
             of(ReadingListActions.failedAddToReadingList({ book }))
           )
@@ -41,10 +46,10 @@ export class ReadingListEffects implements OnInitEffects {
   removeBook$ = createEffect(() =>
     this.actions$.pipe(
       ofType(ReadingListActions.removeFromReadingList),
-      concatMap(({ item }) =>
+      concatMap(({ item, remove }) =>
         this.http.delete(`/api/reading-list/${item.bookId}`).pipe(
           map(() =>
-            ReadingListActions.confirmedRemoveFromReadingList({ item })
+            ReadingListActions.confirmedRemoveFromReadingList({ item,remove })
           ),
           catchError(() =>
             of(ReadingListActions.failedRemoveFromReadingList({ item }))
@@ -54,9 +59,56 @@ export class ReadingListEffects implements OnInitEffects {
     )
   );
 
+  showSnackBarOnAdd$=createEffect(() => 
+        this.actions$.pipe(
+            ofType(ReadingListActions.confirmedAddToReadingList),
+            concatMap((  action  ) => {
+                    const typeItem:ReadingListItem = {
+                        ...action.book,
+                        bookId: action.book.id
+                    }
+                    if(action.add===false){
+                    return this.snackBar.open(
+                        `Added ${action.book.title} to reading list`,'Undo', { duration: 2000}
+                    ).onAction().pipe(
+                      map(() =>
+                      ReadingListActions.removeFromReadingList({ item:typeItem, remove:true })
+                      )
+                    )
+                    }
+                    else{
+                      return [];
+                    }
+            })
+        )
+    );
+
+    showSnackBarOnRemove$=createEffect(() => 
+        this.actions$.pipe(
+            ofType(ReadingListActions.confirmedRemoveFromReadingList),
+            concatMap((  action  ) => {
+              const typeBook:Book = {
+                id: action.item.bookId,
+                ...action.item
+            }
+            if(action.remove===false){
+                    return this.snackBar.open(
+                        `Removed ${action.item.title} to reading list`,'Undo', { duration: 2000}
+                    ).onAction().pipe(
+                      map(() =>
+                      ReadingListActions.addToReadingList({ book:typeBook, add:true })
+                      )
+                    )
+            } 
+            else{
+              return [];
+            }
+            })
+        )
+    )
   ngrxOnInitEffects() {
     return ReadingListActions.init();
   }
 
-  constructor(private actions$: Actions, private http: HttpClient) {}
+  constructor(private actions$: Actions, private http: HttpClient, private snackBar: MatSnackBar, private readonly store: Store) { }
 }

--- a/libs/books/feature/src/lib/book-search/book-search.component.html
+++ b/libs/books/feature/src/lib/book-search/book-search.component.html
@@ -35,7 +35,8 @@
               mat-flat-button
               color="primary"
               (click)="addBookToReadingList(book)"
-              [disabled]="book.isAdded"              
+              [disabled]="book.isAdded"
+              data-testing="add-book-button"              
             >
               Want to Read
             </button>

--- a/libs/books/feature/src/lib/book-search/book-search.component.ts
+++ b/libs/books/feature/src/lib/book-search/book-search.component.ts
@@ -31,7 +31,7 @@ export class BookSearchComponent  {
   }
 
   addBookToReadingList(book: Book) {
-    this.store.dispatch(addToReadingList({ book }));
+    this.store.dispatch(addToReadingList({ book , add:false }));
   }
 
   searchExample() {

--- a/libs/books/feature/src/lib/reading-list/reading-list.component.html
+++ b/libs/books/feature/src/lib/reading-list/reading-list.component.html
@@ -15,6 +15,7 @@
         color="warn"
         [attr.aria-label]="'Remove ' + item.title + ' from reading list'"
         (click)="removeFromReadingList(item)"
+        data-testing = "remove-book-button"
       >
         <mat-icon>remove_circle</mat-icon>
       </button>

--- a/libs/books/feature/src/lib/reading-list/reading-list.component.ts
+++ b/libs/books/feature/src/lib/reading-list/reading-list.component.ts
@@ -13,6 +13,6 @@ export class ReadingListComponent {
   constructor(private readonly store: Store) {}
 
   removeFromReadingList(item) {
-    this.store.dispatch(removeFromReadingList({ item }));
+    this.store.dispatch(removeFromReadingList({ item, remove:false  }));
   }
 }


### PR DESCRIPTION
Undo Add and Remove from reading list

- Implemented undo functionality on addition/removal of book.
- On successful addition to reading list or on successful removal from reading list, snack bar will open with undo button.
- Added test cases to ensure the functionality.

Screen shots

- Lint
![task3 lilnt](https://github.com/RoyDivya/-PUZZLE-DW3/assets/112148648/2fc2f35e-3adc-4e4e-98d9-25855672688a)

- Unit test
![task3 unit test](https://github.com/RoyDivya/-PUZZLE-DW3/assets/112148648/4301c1d1-8d99-4e32-bb20-551d395a39e2)

- e2e test
![e2e updated](https://github.com/RoyDivya/-PUZZLE-DW3/assets/112148648/57ffcce9-fe90-4d72-a286-0382de645b21)

- Task 3 Screenshots
![book added ss](https://github.com/RoyDivya/-PUZZLE-DW3/assets/112148648/2c55a3e4-5f57-4285-9726-54b8153b9676)

![book removed ss](https://github.com/RoyDivya/-PUZZLE-DW3/assets/112148648/fea4352a-11b9-4bb7-b3a9-841ea61c1a9c)

https://github.com/RoyDivya/-PUZZLE-DW3/assets/112148648/9eaf5c4e-9c1d-4e2d-9445-1daf5b7f483e

https://github.com/RoyDivya/-PUZZLE-DW3/assets/112148648/2efd24ac-6995-439c-82b4-5e5f96e6d27c




